### PR TITLE
Change style in this.icon.style turn svg less pixalated

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -34,7 +34,10 @@ class MaccyMenu extends PanelMenu.Button {
   loadConfig() {
     this._settings = ExtensionUtils.getSettings(Me.metadata["settings-schema"]);
 
-    this._settingsC = this._settings.connect("changed::icon", this.setIcon.bind(this));
+    this._settingsC = this._settings.connect(
+      "changed::icon",
+      this.setIcon.bind(this)
+    );
 
     this._settingsC = this._settings.connect(
       "changed::activity-menu-visibility",
@@ -45,6 +48,7 @@ class MaccyMenu extends PanelMenu.Button {
   setIcon() {
     const iconIndex = this._settings.get_int("icon");
     const path = Me.path + ICONS[iconIndex].path;
+    this.icon.style = "width: 24px; height: 24px;";
     this.icon.gicon = Gio.icon_new_for_string(path);
   }
 
@@ -98,7 +102,10 @@ class MaccyMenu extends PanelMenu.Button {
     const items = recentManager.get_items();
     let counter = 0;
     for (let i = 0; i < items.length; i++) {
-      const subMenu = new PopupMenu.PopupImageMenuItem(items[i].get_display_name(), items[i].get_gicon().names[0]);
+      const subMenu = new PopupMenu.PopupImageMenuItem(
+        items[i].get_display_name(),
+        items[i].get_gicon().names[0]
+      );
       popUpMenu.menu.addMenuItem(subMenu);
       if (counter === 15) break;
       counter++;


### PR DESCRIPTION
![image](https://github.com/dgvai/maccymenu-gnome-shell-ext/assets/45501748/c481716b-0202-4142-86c2-254041664c48)
![image](https://github.com/dgvai/maccymenu-gnome-shell-ext/assets/45501748/e8d939a1-4b59-4a2f-96ff-05e19f8e1b91)
